### PR TITLE
Make ivf::list more flexible

### DIFF
--- a/cpp/include/raft/neighbors/detail/ivf_flat_build.cuh
+++ b/cpp/include/raft/neighbors/detail/ivf_flat_build.cuh
@@ -166,8 +166,8 @@ void extend(raft::device_resources const& handle,
   auto stream  = handle.get_stream();
   auto n_lists = index->n_lists();
   auto dim     = index->dim();
-  typename list_spec_wrapper<T>::list_spec<uint32_t> list_device_spec{
-    index->dim(), index->conservative_memory_allocation()};
+  list_spec<uint32_t, T, IdxT> list_device_spec{index->dim(),
+                                                index->conservative_memory_allocation()};
   common::nvtx::range<common::nvtx::domain::raft> fun_scope(
     "ivf_flat::extend(%zu, %u)", size_t(n_rows), dim);
 
@@ -376,8 +376,7 @@ inline void fill_refinement_index(raft::device_resources const& handle,
 
   // Allocate new memory
   auto lists = refinement_index->lists();
-  typename list_spec_wrapper<T>::list_spec<uint32_t> list_device_spec{refinement_index->dim(),
-                                                                      false};
+  list_spec<uint32_t, T, IdxT> list_device_spec{refinement_index->dim(), false};
   for (uint32_t label = 0; label < n_lists; label++) {
     ivf::resize_list(handle, lists[label], list_device_spec, n_candidates, uint32_t(0));
   }

--- a/cpp/include/raft/neighbors/detail/ivf_flat_serialize.cuh
+++ b/cpp/include/raft/neighbors/detail/ivf_flat_serialize.cuh
@@ -89,7 +89,7 @@ void serialize(raft::device_resources const& handle,
   handle.sync_stream();
   serialize_mdspan(handle, of, sizes_host.view());
 
-  typename list_spec_wrapper<T>::list_spec<uint32_t> list_store_spec{index_.dim(), true};
+  list_spec<uint32_t, T, IdxT> list_store_spec{index_.dim(), true};
   for (uint32_t label = 0; label < index_.n_lists(); label++) {
     ivf::serialize_list(handle, of, index_.lists()[label], list_store_spec /*, sizes_host(label)*/);
   }
@@ -140,8 +140,8 @@ auto deserialize(raft::device_resources const& handle, const std::string& filena
   }
   deserialize_mdspan(handle, infile, index_.list_sizes());
 
-  typename list_spec_wrapper<T>::list_spec<uint32_t> list_device_spec{index_.dim(), cma};
-  typename list_spec_wrapper<T>::list_spec<uint32_t> list_store_spec{index_.dim(), true};
+  list_spec<uint32_t, T, IdxT> list_device_spec{index_.dim(), cma};
+  list_spec<uint32_t, T, IdxT> list_store_spec{index_.dim(), true};
   for (uint32_t label = 0; label < index_.n_lists(); label++) {
     ivf::deserialize_list(handle, infile, index_.lists()[label], list_store_spec, list_device_spec);
   }

--- a/cpp/include/raft/neighbors/detail/ivf_pq_serialize.cuh
+++ b/cpp/include/raft/neighbors/detail/ivf_pq_serialize.cuh
@@ -94,10 +94,9 @@ void serialize(raft::device_resources const& handle_,
        handle_.get_stream());
   handle_.sync_stream();
   serialize_mdspan(handle_, of, sizes_host.view());
-  auto list_store_spec = list_spec<uint32_t>{index.pq_bits(), index.pq_dim(), true};
+  auto list_store_spec = list_spec<uint32_t, IdxT>{index.pq_bits(), index.pq_dim(), true};
   for (uint32_t label = 0; label < index.n_lists(); label++) {
-    ivf::serialize_list<list_spec, IdxT, uint32_t>(
-      handle_, of, index.lists()[label], list_store_spec, sizes_host(label));
+    ivf::serialize_list(handle_, of, index.lists()[label], list_store_spec, sizes_host(label));
   }
 
   of.close();
@@ -151,11 +150,10 @@ auto deserialize(raft::device_resources const& handle_, const std::string& filen
   deserialize_mdspan(handle_, infile, index.centers_rot());
   deserialize_mdspan(handle_, infile, index.rotation_matrix());
   deserialize_mdspan(handle_, infile, index.list_sizes());
-  auto list_device_spec = list_spec<uint32_t>{pq_bits, pq_dim, cma};
-  auto list_store_spec  = list_spec<uint32_t>{pq_bits, pq_dim, true};
+  auto list_device_spec = list_spec<uint32_t, IdxT>{pq_bits, pq_dim, cma};
+  auto list_store_spec  = list_spec<uint32_t, IdxT>{pq_bits, pq_dim, true};
   for (auto& list : index.lists()) {
-    ivf::deserialize_list<list_spec, IdxT, uint32_t>(
-      handle_, infile, list, list_store_spec, list_device_spec);
+    ivf::deserialize_list(handle_, infile, list, list_store_spec, list_device_spec);
   }
 
   handle_.sync_stream();

--- a/cpp/include/raft/neighbors/ivf_list.hpp
+++ b/cpp/include/raft/neighbors/ivf_list.hpp
@@ -35,10 +35,12 @@
 namespace raft::neighbors::ivf {
 
 /** The data for a single IVF list. */
-template <template <typename> typename SpecT, typename IdxT, typename SizeT>
-list<SpecT, IdxT, SizeT>::list(raft::device_resources const& res,
-                               const SpecT<SizeT>& spec,
-                               SizeT n_rows)
+template <template <typename, typename...> typename SpecT,
+          typename SizeT,
+          typename... SpecExtraArgs>
+list<SpecT, SizeT, SpecExtraArgs...>::list(raft::device_resources const& res,
+                                           const spec_type& spec,
+                                           size_type n_rows)
   : size{n_rows}
 {
   auto capacity = round_up_safe<SizeT>(n_rows, spec.align_max);
@@ -47,9 +49,8 @@ list<SpecT, IdxT, SizeT>::list(raft::device_resources const& res,
     capacity = std::min<SizeT>(capacity, spec.align_max);
   }
   try {
-    data =
-      make_device_mdarray<typename SpecT<SizeT>::value_type>(res, spec.make_list_extents(capacity));
-    indices = make_device_vector<IdxT, SizeT>(res, capacity);
+    data    = make_device_mdarray<value_type>(res, spec.make_list_extents(capacity));
+    indices = make_device_vector<index_type, SizeT>(res, capacity);
   } catch (std::bad_alloc& e) {
     RAFT_FAIL(
       "ivf::list: failed to allocate a big enough list to hold all data "
@@ -60,20 +61,22 @@ list<SpecT, IdxT, SizeT>::list(raft::device_resources const& res,
       e.what());
   }
   // Fill the index buffer with a pre-defined marker for easier debugging
-  thrust::fill_n(
-    res.get_thrust_policy(), indices.data_handle(), indices.size(), ivf::kInvalidRecord<IdxT>);
+  thrust::fill_n(res.get_thrust_policy(),
+                 indices.data_handle(),
+                 indices.size(),
+                 ivf::kInvalidRecord<index_type>);
 }
 
 /**
  * Resize a list by the given id, so that it can contain the given number of records;
  * copy the data if necessary.
  */
-template <template <typename> typename SpecT, typename IdxT, typename SizeT>
+template <typename ListT>
 void resize_list(raft::device_resources const& res,
-                 std::shared_ptr<list<SpecT, IdxT, SizeT>>& orig_list,  // NOLINT
-                 const SpecT<SizeT>& spec,
-                 SizeT new_used_size,
-                 SizeT old_used_size)
+                 std::shared_ptr<ListT>& orig_list,  // NOLINT
+                 const typename ListT::spec_type& spec,
+                 typename ListT::size_type new_used_size,
+                 typename ListT::size_type old_used_size)
 {
   bool skip_resize = false;
   if (orig_list) {
@@ -92,11 +95,11 @@ void resize_list(raft::device_resources const& res,
     old_used_size = 0;
   }
   if (skip_resize) { return; }
-  auto new_list = std::make_shared<list<SpecT, IdxT, SizeT>>(res, spec, new_used_size);
+  auto new_list = std::make_shared<ListT>(res, spec, new_used_size);
   if (old_used_size > 0) {
-    auto copied_data_extents = SpecT<size_t>{spec}.make_list_extents(old_used_size);
+    auto copied_data_extents = spec.make_list_extents(old_used_size);
     auto copied_view =
-      make_mdspan<typename SpecT<SizeT>::value_type, size_t, row_major, false, true>(
+      make_mdspan<typename ListT::value_type, typename ListT::size_type, row_major, false, true>(
         new_list->data.data_handle(), copied_data_extents);
     copy(copied_view.data_handle(),
          orig_list->data.data_handle(),
@@ -111,21 +114,24 @@ void resize_list(raft::device_resources const& res,
   new_list.swap(orig_list);
 }
 
-template <template <typename> typename SpecT, typename IdxT, typename SizeT>
-void serialize_list(const raft::device_resources& handle,
+template <typename ListT>
+auto serialize_list(const raft::device_resources& handle,
                     std::ostream& os,
-                    const list<SpecT, IdxT, SizeT>& ld,
-                    const SpecT<SizeT>& store_spec,
-                    std::optional<SizeT> size_override = std::nullopt)
+                    const ListT& ld,
+                    const typename ListT::spec_type& store_spec,
+                    std::optional<typename ListT::size_type> size_override = std::nullopt)
+  -> enable_if_valid_list_t<ListT>
 {
-  auto size = size_override.value_or(ld.size.load());
+  using size_type = typename ListT::size_type;
+  auto size       = size_override.value_or(ld.size.load());
   serialize_scalar(handle, os, size);
   if (size == 0) { return; }
 
   auto data_extents = store_spec.make_list_extents(size);
   auto data_array =
-    make_host_mdarray<typename SpecT<SizeT>::value_type, SizeT, row_major>(data_extents);
-  auto inds_array = make_host_mdarray<IdxT, SizeT, row_major>(make_extents<SizeT>(size));
+    make_host_mdarray<typename ListT::value_type, size_type, row_major>(data_extents);
+  auto inds_array = make_host_mdarray<typename ListT::index_type, size_type, row_major>(
+    make_extents<size_type>(size));
   copy(data_array.data_handle(), ld.data.data_handle(), data_array.size(), handle.get_stream());
   copy(inds_array.data_handle(), ld.indices.data_handle(), inds_array.size(), handle.get_stream());
   handle.sync_stream();
@@ -133,34 +139,37 @@ void serialize_list(const raft::device_resources& handle,
   serialize_mdspan(handle, os, inds_array.view());
 }
 
-template <template <typename> typename SpecT, typename IdxT, typename SizeT>
-void serialize_list(const raft::device_resources& handle,
+template <typename ListT>
+auto serialize_list(const raft::device_resources& handle,
                     std::ostream& os,
-                    const std::shared_ptr<list<SpecT, IdxT, SizeT>>& ld,
-                    const SpecT<SizeT>& store_spec,
-                    std::optional<SizeT> size_override = std::nullopt)
+                    const std::shared_ptr<ListT>& ld,
+                    const typename ListT::spec_type& store_spec,
+                    std::optional<typename ListT::size_type> size_override = std::nullopt)
+  -> enable_if_valid_list_t<ListT>
 {
   if (ld) {
-    return serialize_list(handle, os, *ld, store_spec, size_override);
+    return serialize_list<ListT>(handle, os, *ld, store_spec, size_override);
   } else {
-    return serialize_scalar(handle, os, SizeT{0});
+    return serialize_scalar(handle, os, typename ListT::size_type{0});
   }
 }
 
-template <template <typename> typename SpecT, typename IdxT, typename SizeT>
-void deserialize_list(const raft::device_resources& handle,
+template <typename ListT>
+auto deserialize_list(const raft::device_resources& handle,
                       std::istream& is,
-                      std::shared_ptr<list<SpecT, IdxT, SizeT>>& ld,
-                      const SpecT<SizeT>& store_spec,
-                      const SpecT<SizeT>& device_spec)
+                      std::shared_ptr<ListT>& ld,
+                      const typename ListT::spec_type& store_spec,
+                      const typename ListT::spec_type& device_spec) -> enable_if_valid_list_t<ListT>
 {
-  auto size = deserialize_scalar<SizeT>(handle, is);
+  using size_type = typename ListT::size_type;
+  auto size       = deserialize_scalar<size_type>(handle, is);
   if (size == 0) { return ld.reset(); }
-  std::make_shared<list<SpecT, IdxT, SizeT>>(handle, device_spec, size).swap(ld);
+  std::make_shared<ListT>(handle, device_spec, size).swap(ld);
   auto data_extents = store_spec.make_list_extents(size);
   auto data_array =
-    make_host_mdarray<typename SpecT<SizeT>::value_type, SizeT, row_major>(data_extents);
-  auto inds_array = make_host_mdarray<IdxT, SizeT, row_major>(make_extents<SizeT>(size));
+    make_host_mdarray<typename ListT::value_type, size_type, row_major>(data_extents);
+  auto inds_array = make_host_mdarray<typename ListT::index_type, size_type, row_major>(
+    make_extents<size_type>(size));
   deserialize_mdspan(handle, is, data_array.view());
   deserialize_mdspan(handle, is, inds_array.view());
   copy(ld->data.data_handle(), data_array.data_handle(), data_array.size(), handle.get_stream());

--- a/cpp/include/raft/neighbors/ivf_pq_types.hpp
+++ b/cpp/include/raft/neighbors/ivf_pq_types.hpp
@@ -161,9 +161,10 @@ constexpr static uint32_t kIndexGroupVecLen = 16;
 template <typename IdxT>
 constexpr static IdxT kOutOfBoundsRecord = std::numeric_limits<IdxT>::max();
 
-template <typename SizeT = uint32_t>
+template <typename SizeT, typename IdxT>
 struct list_spec {
   using value_type = uint8_t;
+  using index_type = IdxT;
   /** PQ-encoded data stored in the interleaved format:
    *
    *    [ ceildiv(list_size, kIndexGroupSize)
@@ -190,7 +191,7 @@ struct list_spec {
 
   // Allow casting between different size-types (for safer size and offset calculations)
   template <typename OtherSizeT>
-  constexpr explicit list_spec(const list_spec<OtherSizeT>& other_spec)
+  constexpr explicit list_spec(const list_spec<OtherSizeT, IdxT>& other_spec)
     : pq_bits{other_spec.pq_bits},
       pq_dim{other_spec.pq_dim},
       align_min{other_spec.align_min},
@@ -211,7 +212,7 @@ struct list_spec {
 };
 
 template <typename IdxT, typename SizeT = uint32_t>
-using list_data = ivf::list<list_spec, IdxT, SizeT>;
+using list_data = ivf::list<list_spec, SizeT, IdxT>;
 
 /**
  * @brief IVF-PQ index.


### PR DESCRIPTION
Make ivf::list accept more flexible list_spec to avoid nested templates and simplify the signatures of helper functions.